### PR TITLE
[PJG1-19] Front-End: Delete Inventory Modal/Component (Responsive)

### DIFF
--- a/src/Components/InventoryList/InventoryList.js
+++ b/src/Components/InventoryList/InventoryList.js
@@ -11,6 +11,10 @@ const InventoryList = () =>{
     const [data, setData] = useState([])
 
     useEffect(()=>{
+        requestInventoryList();
+    }, [])
+
+    const requestInventoryList = () => {
         axios.get('http://localhost:8080/inventory')
         .then(result =>{
             setData(result.data)
@@ -18,7 +22,7 @@ const InventoryList = () =>{
         .catch(error =>{
             console.log(error)
         })
-    }, [])
+    }
 
     return(
         <div className='inventoryList__wrapper-container'>
@@ -42,6 +46,7 @@ const InventoryList = () =>{
                     quantity={singleInventory.quantity}
                     status={singleInventory.status}
                     warehouseID={singleInventory.warehouseID}
+                    onDataChange={requestInventoryList}
                     key={singleInventory.id}/>
                 })} 
             </div>

--- a/src/Components/InventoryListRow/InventoryListRow.js
+++ b/src/Components/InventoryListRow/InventoryListRow.js
@@ -3,12 +3,15 @@ import ChevronIcon from '../../Assets/Icons/chevron_right-24px.svg'
 import BinIcon from '../../Assets/Icons/delete_outline-24px.svg'
 import PencilIcon from '../../Assets/Icons/edit-24px.svg'
 import { Link } from 'react-router-dom'
-import React, {useEffect, useRef} from 'react'
+import React, {useEffect, useState, useRef} from 'react'
+import axios from "axios";
 
+import ModalDialog from './../ModalDialog/ModalDialog.jsx';
 
 const InventoryListRow = (props) => {  
 
     const statusTextElement = useRef([])
+    const [showModalDialog, setShowModalDialog] = useState(false);
 
     useEffect(()=>{
         if (props.status === 'In Stock'){
@@ -18,8 +21,34 @@ const InventoryListRow = (props) => {
         }
     })
 
+    const openModalDialog = () => {
+        setShowModalDialog(true);
+    }
+
+    const closeModalDialog = () => {
+        setShowModalDialog(false);
+    }
+
+    const deleteInventoryCallback = async () => {
+        const response = await axios.delete(`http://localhost:8080/inventory/${props.itemID}`);
+
+        if (response.data?.deleteInventory) {
+            props.onDataChange();
+        }
+
+        setShowModalDialog(false);
+    }
+
+
     return(
         <>
+            <ModalDialog 
+                showModalDialog={showModalDialog}
+                title={`Delete ${props.item} inventory item?`}
+                content={`Please confirm that you'd like to delete ${props.item} from the inventory list. You won't be able to undo this action.`}
+                onCancel={closeModalDialog}
+                onDelete={deleteInventoryCallback}>
+            </ModalDialog>
             <div className='inventoryListRow'>
                 <div className='inventoryListRow__container inventoryListRow__container--primary'>
                     <div className='inventoryListRow__header-container'>
@@ -65,7 +94,7 @@ const InventoryListRow = (props) => {
                     </div>
                 </div>
                 <div className='inventoryListRow__container inventoryListRow__container--senary'>
-                    <img className='inventoryListRow__image' src={BinIcon} alt="Garbage Bin Icon Button" />
+                    <img className='inventoryListRow__image' src={BinIcon} onClick={openModalDialog} alt="Garbage Bin Icon Button" />
                     <img className='inventoryListRow__image' src={PencilIcon} alt="Pencil Icon Button" />
                 </div>
             </div>

--- a/src/Components/ModalDialog/ModalDialog.jsx
+++ b/src/Components/ModalDialog/ModalDialog.jsx
@@ -7,6 +7,7 @@ const ModalDialog = (props) => {
     
     return (
         <ReactModal
+            ariaHideApp={ false}
             className={'modal-dialog'}
             overlayClassName={'modal-dialog__overlay'}
             isOpen={props.showModalDialog}


### PR DESCRIPTION
Jira Item Link:

https://brainstationeducation.atlassian.net/browse/PJG1-19?atlOrigin=eyJpIjoiOTFhMTVmZjJmMGY1NDYyODkzMTc4ZDRiN2U0NjVmNmQiLCJwIjoiaiJ9

Description:
The warehouse delete button is already hooked up with the backend - this is the equivalent for inventory. Please note that there is an associated PR on the backend as well (https://github.com/jumuir/instock-api/pull/18/files), for a bug with the inventory delete route.