### PR TITLE
Bugfix: Add Warehouse Page Empty Field Now Works as Expected.

### DIFF
--- a/src/Components/AddWarehouse/AddWarehouse.js
+++ b/src/Components/AddWarehouse/AddWarehouse.js
@@ -11,15 +11,14 @@ const AddWarehouse = () => {
   const [fieldRequiredMessage, setFieldRequiredMessage] = useState({});
 
   const errorHandler = (e) => {
-    const form = e.target.value;
 
-    setInputState({ ...inputState, [e.target.name]: form });
+    setInputState({ ...inputState, [e.target.name]: e.target.value });
 
     // updating state for error message display
 
-    if (form.value !== '') {
+    if (e.target.value.trim() !== '') {
       setFieldRequiredMessage({ ...fieldRequiredMessage, [e.target.name]: e.target.value });
-    } else if (form.value === '') {
+    } else if (e.target.value.trim() === '') {
       setFieldRequiredMessage({ ...fieldRequiredMessage, [e.target.name]: undefined });
     }
   };


### PR DESCRIPTION
The fix was since form is already e.target.value, form.value would be e.target.value.value, which is always going to be undefined.